### PR TITLE
Use client IP by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,6 +43,9 @@ func main() {
 	e.Static("*", "./static")
 
 	// Bind all API endpoint handlers
+	e.GET("/lookup", func(c echo.Context) error {
+		return c.JSON(http.StatusOK, ic.Lookup(c.RealIP()))
+	})
 	e.GET("/lookup/:ip", func(c echo.Context) error {
 		return c.JSON(http.StatusOK, ic.Lookup(c.Param("ip")))
 	})


### PR DESCRIPTION
If there is no argument in `/lookup/`, use the one of the client one by default.